### PR TITLE
Fix: correção para renderização duplicada de componentes

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,11 +1,11 @@
-import { Injector, NgModule } from "@angular/core";
-import { ChartModule } from "primeng/chart";
-import { BrowserModule } from "@angular/platform-browser";
+import { Injector, NgModule } from '@angular/core';
+import { ChartModule } from 'primeng/chart';
+import { BrowserModule } from '@angular/platform-browser';
 
-import { AppComponent } from "./app.component";
-import { createCustomElement } from "@angular/elements";
-import { DoughnutChartModule } from "./doughnut-chart/doughnut-chart.module";
-import { BarChartModule } from "./bar-chart/bar-chart.module";
+import { AppComponent } from './app.component';
+import { createCustomElement } from '@angular/elements';
+import { DoughnutChartModule } from './doughnut-chart/doughnut-chart.module';
+import { BarChartModule } from './bar-chart/bar-chart.module';
 
 @NgModule({
   declarations: [AppComponent],
@@ -15,7 +15,10 @@ import { BarChartModule } from "./bar-chart/bar-chart.module";
 })
 export class AppModule {
   constructor(private injector: Injector) {
-    const element = createCustomElement(AppComponent, { injector: injector });
-    customElements.define("angular-app-component", element);
+    const tagName = 'angular-app-component';
+    if (!customElements.get(tagName)) {
+      const element = createCustomElement(AppComponent, { injector });
+      customElements.define(tagName, element);
+    }
   }
 }

--- a/src/app/bar-chart/bar-chart.module.ts
+++ b/src/app/bar-chart/bar-chart.module.ts
@@ -1,7 +1,7 @@
-import { Injector, NgModule } from "@angular/core";
-import { BarChartComponent } from "./bar-chart.component";
-import { createCustomElement } from "@angular/elements";
-import { ChartModule } from "primeng/chart";
+import { Injector, NgModule } from '@angular/core';
+import { BarChartComponent } from './bar-chart.component';
+import { createCustomElement } from '@angular/elements';
+import { ChartModule } from 'primeng/chart';
 
 @NgModule({
   declarations: [BarChartComponent],
@@ -10,9 +10,10 @@ import { ChartModule } from "primeng/chart";
 })
 export class BarChartModule {
   constructor(private injector: Injector) {
-    const element = createCustomElement(BarChartComponent, {
-      injector: injector,
-    });
-    customElements.define("angular-bar-chart-component", element);
+    const tagName = 'angular-bar-chart-component';
+    if (!customElements.get(tagName)) {
+      const element = createCustomElement(BarChartComponent, { injector });
+      customElements.define(tagName, element);
+    }
   }
 }

--- a/src/app/doughnut-chart/doughnut-chart.module.ts
+++ b/src/app/doughnut-chart/doughnut-chart.module.ts
@@ -1,7 +1,7 @@
-import { Injector, NgModule } from "@angular/core";
-import { DoughnutChartComponent } from "./doughnut-chart.component";
-import { createCustomElement } from "@angular/elements";
-import { ChartModule } from "primeng/chart";
+import { Injector, NgModule } from '@angular/core';
+import { DoughnutChartComponent } from './doughnut-chart.component';
+import { createCustomElement } from '@angular/elements';
+import { ChartModule } from 'primeng/chart';
 
 @NgModule({
   declarations: [DoughnutChartComponent],
@@ -10,9 +10,10 @@ import { ChartModule } from "primeng/chart";
 })
 export class DoughnutChartModule {
   constructor(private injector: Injector) {
-    const element = createCustomElement(DoughnutChartComponent, {
-      injector: injector,
-    });
-    customElements.define("angular-doughnut-chart-component", element);
+    const tagName = 'angular-doughnut-chart-component';
+    if (!customElements.get(tagName)) {
+      const element = createCustomElement(DoughnutChartComponent, { injector });
+      customElements.define(tagName, element);
+    }
   }
 }

--- a/src/loadApp.ts
+++ b/src/loadApp.ts
@@ -1,17 +1,23 @@
-import "zone.js";
-import { enableProdMode } from '@angular/core';
+import 'zone.js';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-
 import { AppModule } from './app/app.module';
-import { environment } from './environments/environment';
 
-if (environment.production) {
-  enableProdMode();
+let ngPlatform: any = null;
+
+export function mount() {
+  if (!ngPlatform) {
+    platformBrowserDynamic()
+      .bootstrapModule(AppModule)
+      .then((platform) => {
+        ngPlatform = platform;
+      })
+      .catch((err) => console.error('Erro ao inicializar Angular:', err));
+  }
 }
 
-const mount = () => {
-  platformBrowserDynamic().bootstrapModule(AppModule)
-    .catch(err => console.error(err));
+export function unmount() {
+  if (ngPlatform) {
+    ngPlatform.destroy();
+    ngPlatform = null;
+  }
 }
-
-export { mount }


### PR DESCRIPTION
### Descrição

Notei que o componente estava com problemas de renderização no app root por conta do tempo de carregamento. Isso acontecia porque os componentes estavam sendo renderizados mais de uma vez dentro do ecossistema do Angular. Para resolver garanti que o registro dos módulos só ocorram quando esse registro ainda não existir e adicionei um método de `unmount` para permitir que o app root desmonte o componente do Angular antes de tentar montá-lo novamente.